### PR TITLE
Fixing broken link

### DIFF
--- a/_grants/jacobsen_ragnhildirene_2022.md
+++ b/_grants/jacobsen_ragnhildirene_2022.md
@@ -6,7 +6,7 @@ author: Ragnhild Irene Jacobsen
 ORCID: 0000-0001-9521-5044
 year: '2022'
 institution: NTNU
-link: 10.5281/zenodo.7760329
+link: ["https://doi.org/10.5281/zenodo.7760329"]
 funder: The Research Council of Norway
 program: Researcher Project for Scientific Renewal
 discipline: Neuroscience, marine biology


### PR DESCRIPTION
Original link was just the DOI (my bad), which lead to a 404 page. Have replaced with full link.