### PR TITLE
Replace Google Analytics with Plausible for usage tracking

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -28,14 +28,7 @@
   <!-- RSS -->
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
 
-  <!-- Google Analytics -->
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  <!--Plausible Analytics-->
+  <script defer data-domain="ogrants.org" src="https://plausible.io/js/script.js"></script>
 
-    ga('create', 'UA-102349879-1', 'auto');
-    ga('send', 'pageview');
-  </script>
 </head>


### PR DESCRIPTION
GA is sun setting it's old system and I'm switching over to Plausible for more ethical usage tracking.

I'm happy to keep the monitoring going with this change or to do something else. We'll start to lose data tomorrow (sorry to being slow about this).